### PR TITLE
CDAP-15246. Fix macros checks, remove deprecated API usage, some minor fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <mockito.version>1.10.19</mockito.version>
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
+    <jackson2.version>2.9.8</jackson2.version>
     <json.version>20180813</json.version>
     <awaitility.version>3.1.6</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>
@@ -232,6 +233,12 @@
       <version>${awaitility.version}</version>
     </dependency>
 
+    <!-- Cometd requires this to use JacksonJSONContextClient -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson2.version}</version>
+    </dependency>
     <!-- Salesforce runtime dependencies to avoid NoClassDefFoundError -->
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
@@ -243,6 +250,7 @@
       <artifactId>jackson-mapper-asl</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
@@ -118,14 +118,11 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
    * @return true if none of the connection properties contains macro, false otherwise
    */
   public boolean canAttemptToEstablishConnection() {
-    if (containsMacro(SalesforceConstants.PROPERTY_CLIENT_ID)
+    return !(containsMacro(SalesforceConstants.PROPERTY_CLIENT_ID)
       || containsMacro(SalesforceConstants.PROPERTY_CLIENT_SECRET)
       || containsMacro(SalesforceConstants.PROPERTY_USERNAME)
       || containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
-      || containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL)) {
-      return false;
-    }
-    return true;
+      || containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL));
   }
 
   private void validateConnection() {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSplit.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSplit.java
@@ -53,12 +53,12 @@ public class SalesforceSplit extends InputSplit implements Writable {
   }
 
   @Override
-  public long getLength() throws IOException, InterruptedException {
+  public long getLength() {
     return 0;
   }
 
   @Override
-  public String[] getLocations() throws IOException, InterruptedException {
+  public String[] getLocations() {
     return new String[0];
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceReceiver.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceReceiver.java
@@ -55,7 +55,7 @@ public class SalesforceReceiver extends Receiver<String> {
         .setNameFormat(RECEIVER_THREAD_NAME + "-%d")
         .build();
 
-    Executors.newSingleThreadExecutor(namedThreadFactory).submit(() -> receive());
+    Executors.newSingleThreadExecutor(namedThreadFactory).submit(this::receive);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -51,39 +51,36 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
   private static final Logger LOG = LoggerFactory.getLogger(SalesforceStreamingSourceConfig.class);
   private static final long serialVersionUID = 4218063781902315444L;
 
-  protected static final String ENABLED_KEYWORD = "Enabled";
-  protected static final String PROPERTY_PUSHTOPIC_NAME = "pushTopicName";
-  protected static final String PROPERTY_PUSHTOPIC_QUERY = "pushTopicQuery";
-  protected static final String PROPERTY_SOBJECT_NAME = "sObjectName";
+  private static final Pattern isValidFieldNamePattern = Pattern.compile("[a-zA-Z0-9.-_]+");
 
-  private static Pattern isValidFieldNamePattern = Pattern.compile("[a-zA-Z0-9.-_]+");
+  protected static final String ENABLED_KEYWORD = "Enabled";
+  protected static final String PROPERTY_PUSH_TOPIC_NAME = "pushTopicName";
+  protected static final String PROPERTY_PUSH_TOPIC_QUERY = "pushTopicQuery";
+  protected static final String PROPERTY_SOBJECT_NAME = "sObjectName";
 
   @Description("Salesforce push topic name. Plugin will track updates from this topic. If topic does not exist, " +
     "it will be automatically created. " +
     "To manually create pushTopic use Salesforce workbench or Apex code or API.")
-  @Name(PROPERTY_PUSHTOPIC_NAME)
+  @Name(PROPERTY_PUSH_TOPIC_NAME)
   @Macro
   private String pushTopicName;
 
   @Description("Salesforce push topic query. The query is used by Salesforce to send updates to push topic. " +
     "This field not required, if you are using an existing push topic.")
   @Nullable
-  @Name(PROPERTY_PUSHTOPIC_QUERY)
+  @Name(PROPERTY_PUSH_TOPIC_QUERY)
   @Macro
   private String pushTopicQuery;
 
   @Description("Push topic property, which specifies if a create operation should generate a record.")
-  @Nullable
   @Name("pushTopicNotifyCreate")
   private String pushTopicNotifyCreate;
 
   @Description("Push topic property, which specifies if a update operation should generate a record.")
-  @Nullable
   @Name("pushTopicNotifyUpdate")
   private String pushTopicNotifyUpdate;
 
   @Description("Push topic property, which specifies if an delete operation should generate a record.")
-  @Nullable
   @Name("pushTopicNotifyDelete")
   private String pushTopicNotifyDelete;
 
@@ -104,7 +101,6 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
     "for the evaluated records only if they match the criteria specified in the WHERE clause.\n" +
     "Where - Changes to fields referenced in the WHERE clause are evaluated. Notifications are generated " +
     "for the evaluated records only if they match the criteria specified in the WHERE clause.")
-  @Nullable
   @Name("pushTopicNotifyForFields")
   private String pushTopicNotifyForFields;
 
@@ -140,16 +136,12 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
     return pushTopicNotifyForFields;
   }
 
-  @Nullable
-  public String getSObjectName() {
-    return sObjectName;
-  }
-
   /**
    * Get query to use, either pushTopicQuery or query generated using sObjectName.
    *
    * @return query or null if query was not specified via pushTopicQuery and sObjectName.
    */
+  @Nullable
   public String getQuery() {
     if (!Strings.isNullOrEmpty(pushTopicQuery)) {
       return pushTopicQuery;
@@ -168,7 +160,8 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
    * If pushTopic does not exist it is created.
    */
   public void ensurePushTopicExistAndWithCorrectFields() {
-    if (containsMacro(PROPERTY_PUSHTOPIC_NAME) || containsMacro(PROPERTY_PUSHTOPIC_QUERY)) {
+    if (containsMacro(PROPERTY_PUSH_TOPIC_NAME) ||
+      containsMacro(PROPERTY_PUSH_TOPIC_QUERY) || !canAttemptToEstablishConnection()) {
       return;
     }
 
@@ -185,7 +178,7 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
         if (Strings.isNullOrEmpty(query)) {
           throw new InvalidConfigPropertyException("SOQL query or SObject name must be provided, unless " +
                                                      "existing pushTopic is used",
-                                                   SalesforceStreamingSourceConfig.PROPERTY_PUSHTOPIC_QUERY);
+                                                   SalesforceStreamingSourceConfig.PROPERTY_PUSH_TOPIC_QUERY);
         }
 
         pushTopic = new SObjectBuilder()
@@ -274,7 +267,12 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
     }
   }
 
+  @Nullable
   private String getSObjectQuery() {
+    if (!canAttemptToEstablishConnection()) {
+      return null;
+    }
+
     try {
       // Text areas are not supported in streaming api queries that's why we are skipping them.
       // Streaming API would respond with "large text area fields are not supported"


### PR DESCRIPTION
1. Fix Streaming plugin validation failure when macros are present in credentials.
2. When building Salesforce project, there is warning since the deprecated API is used.
`.../salesforce-plugins/src/main/java/co/cask/hydrator/salesforce/plugin/source/streaming/SalesforcePushTopicListener.java uses or overrides a deprecated API.`
Rewrote the code to avoid using deprecated method org.cometd.bayeux.Message#getJson
For generating json from message in new API jackson or jetty has to be used. Using jackson in our case.
3. PushTopicNotifyCreate, pushTopicNotifyUpdate, pushTopicNotifyDelete are marked as nullable but based on widget configuration, they can not be null.
4. Rename constants "PUSHTOPIC" -> "PUSH_TOPIC"
```
  protected static final String PROPERTY_PUSHTOPIC_NAME = "pushTopicName";
  protected static final String PROPERTY_PUSHTOPIC_QUERY = "pushTopicQuery";
```
5. Add final:
`private static Pattern isValidFieldNamePattern = Pattern.compile("[a-zA-Z0-9.-_]+");`