### PR TITLE
CDAP-15319 Salesforce Batch Source: read the response in a streaming fashion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <mockito.version>1.10.19</mockito.version>
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.8</jackson2.version>
+    <jackson2.version>2.6.7</jackson2.version>
     <json.version>20180813</json.version>
     <awaitility.version>3.1.6</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
@@ -22,8 +22,10 @@ import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -218,7 +220,7 @@ public class SalesforceRecordReaderTest {
                                                List<Map<String, Object>> expectedRecords) throws Exception {
     MapToRecordTransformer transformer = new MapToRecordTransformer();
     SalesforceRecordReader reader = new SalesforceRecordReader(schema);
-    reader.setupParser(csvString);
+    reader.setupParser(new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8)));
 
     Field fieldsField = StructuredRecord.class.getDeclaredField("fields");
     fieldsField.setAccessible(true);


### PR DESCRIPTION
Previously for every batch we formed response as String and than read it.
The change makes RecordReader read directly from InputStream for a batch.