### PR TITLE
CDAP-15307. Rename Client Id / Secret to Consumer Key / Consumer Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ By default all integration tests will be skipped, since Salesforce credentials a
 
 Instructions to run the tests:
  1. Create/use existing Salesforce account
- 2. Create connected application within the account to get clientId and clientSecret
+ 2. Create connected application within the account to get consumerKey and consumerSecret
  3. Run the tests using the command below:
 
 ```
-mvn clean test -Dsalesforce.test.clientId= -Dsalesforce.test.clientSecret= -Dsalesforce.test.username= -Dsalesforce.test.password=
+mvn clean test -Dsalesforce.test.consumerKey= -Dsalesforce.test.consumerSecret= -Dsalesforce.test.username= -Dsalesforce.test.password=
 ```
 
 # Contact

--- a/docs/Salesforce-batchsource.md
+++ b/docs/Salesforce-batchsource.md
@@ -18,11 +18,11 @@ Configuration
 
 **Password:** Salesforce password.
 
-**Client Id:** Application Client Id. This is also called "Consumer Key" in Salesforce UI.
-To create Client Id user needs to create a connected application in Salesforce first.
+**Consumer Key:** Application Consumer Key. This is also known as the OAuth client id.
+A Salesforce connected application must be created in order to get a consumer key.
 
-**Client Secret:** Application Client Secret. This is also called "Consumer Secret" in Salesforce UI.
-To create Client Secret user needs to create a connected application in Salesforce first.
+**Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
+A Salesforce connected application must be created in order to get a client secret.
 
 **Login Url:** Salesforce OAuth2 login url.
 

--- a/docs/Salesforce-streamingsource.md
+++ b/docs/Salesforce-streamingsource.md
@@ -25,11 +25,11 @@ Configuration
 
 **Password:** Salesforce password.
 
-**Client Id:** Application Client Id. This is also called "Consumer Key" in Salesforce UI.
-To create a Client Id, the user needs to create a connected application in Salesforce first.
+**Consumer Key:** Application Consumer Key. This is also known as the OAuth client id.
+A Salesforce connected application must be created in order to get a consumer key.
 
-**Client Secret:** Application Client Secret. This is also called "Consumer Secret" in Salesforce UI.
-To create a Client Secret, the user needs to create a connected application in Salesforce first.
+**Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
+A Salesforce connected application must be created in order to get a client secret.
 
 **Login Url:** Salesforce OAuth2 login url.
 

--- a/docs/SalesforceMultiObjects-batchsource.md
+++ b/docs/SalesforceMultiObjects-batchsource.md
@@ -18,11 +18,11 @@ Configuration
 
 **Password:** Salesforce password.
 
-**Client Id:** Application Client Id. This is also called "Consumer Key" in the Salesforce UI.
-To create a Client Id, a connected application first needs to be created in Salesforce.
+**Consumer Key:** Application Consumer Key. This is also known as the OAuth client id.
+A Salesforce connected application must be created in order to get a consumer key.
 
-**Client Secret:** Application Client Secret. This is also called "Consumer Secret" in the Salesforce UI.
-To create a Client Secret, a connected application first needs to be created in Salesforce.
+**Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
+A Salesforce connected application must be created in order to get a client secret.
 
 **Login Url:** Salesforce OAuth2 login url.
 

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -46,14 +46,15 @@ public class SalesforceConnectionUtil {
    *
    * @param username Salesforce username
    * @param password Salesforce password
-   * @param clientId Salesforce client id
-   * @param clientSecret Salesforce client secret
+   * @param consumerKey Salesforce consumer key
+   * @param consumerSecret Salesforce consumer secret
    * @param loginUrl Salesforce authentication url
    * @return authenticator credentials
    */
-  public static AuthenticatorCredentials getAuthenticatorCredentials(String username, String password, String clientId,
-                                                                     String clientSecret, String loginUrl) {
-    return new AuthenticatorCredentials(username, password, clientId, clientSecret, loginUrl);
+  public static AuthenticatorCredentials getAuthenticatorCredentials(String username, String password,
+                                                                     String consumerKey, String consumerSecret,
+                                                                     String loginUrl) {
+    return new AuthenticatorCredentials(username, password, consumerKey, consumerSecret, loginUrl);
   }
 
   /**
@@ -65,8 +66,8 @@ public class SalesforceConnectionUtil {
   public static AuthenticatorCredentials getAuthenticatorCredentials(Configuration conf) {
     return getAuthenticatorCredentials(conf.get(SalesforceConstants.CONFIG_USERNAME),
                                        conf.get(SalesforceConstants.CONFIG_PASSWORD),
-                                       conf.get(SalesforceConstants.CONFIG_CLIENT_ID),
-                                       conf.get(SalesforceConstants.CONFIG_CLIENT_SECRET),
+                                       conf.get(SalesforceConstants.CONFIG_CONSUMER_KEY),
+                                       conf.get(SalesforceConstants.CONFIG_CONSUMER_SECRET),
                                        conf.get(SalesforceConstants.CONFIG_LOGIN_URL));
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -23,17 +23,17 @@ public class SalesforceConstants {
   public static final String API_VERSION = "45.0";
   public static final String REFERENCE_NAME_DELIMITER = ".";
 
-  public static final String PROPERTY_CLIENT_ID = "clientId";
-  public static final String PROPERTY_CLIENT_SECRET = "clientSecret";
+  public static final String PROPERTY_CONSUMER_KEY = "consumerKey";
+  public static final String PROPERTY_CONSUMER_SECRET = "consumerSecret";
   public static final String PROPERTY_USERNAME = "username";
   public static final String PROPERTY_PASSWORD = "password";
   public static final String PROPERTY_LOGIN_URL = "loginUrl";
   public static final String PROPERTY_ERROR_HANDLING = "errorHandling";
 
-  public static final String CONFIG_CLIENT_ID = "mapred.salesforce.client.id";
+  public static final String CONFIG_CONSUMER_KEY = "mapred.salesforce.consumer.key";
   public static final String CONFIG_PASSWORD = "mapred.salesforce.password";
   public static final String CONFIG_USERNAME = "mapred.salesforce.user";
-  public static final String CONFIG_CLIENT_SECRET = "mapred.salesforce.client.secret";
+  public static final String CONFIG_CONSUMER_SECRET = "mapred.salesforce.consumer.secret";
   public static final String CONFIG_LOGIN_URL = "mapred.salesforce.login.url";
 
   public static final int INTERVAL_FILTER_MIN_VALUE = 0;

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
@@ -70,8 +70,8 @@ public class Authenticator {
     try {
       httpClient.start();
       String response = httpClient.POST(credentials.getLoginUrl()).param("grant_type", "password")
-        .param("client_id", credentials.getClientId())
-        .param("client_secret", credentials.getClientSecret())
+        .param("client_id", credentials.getConsumerKey())
+        .param("client_secret", credentials.getConsumerSecret())
         .param("username", credentials.getUsername())
         .param("password", credentials.getPassword()).send().getContentAsString();
       return GSON.fromJson(response, AuthResponse.class);

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
@@ -25,16 +25,16 @@ import java.util.Objects;
 public class AuthenticatorCredentials implements Serializable {
   private final String username;
   private final String password;
-  private final String clientId;
-  private final String clientSecret;
+  private final String consumerKey;
+  private final String consumerSecret;
   private final String loginUrl;
 
   public AuthenticatorCredentials(String username, String password,
-                                  String clientId, String clientSecret, String loginUrl) {
+                                  String consumerKey, String consumerSecret, String loginUrl) {
     this.username = username;
     this.password = password;
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
+    this.consumerKey = consumerKey;
+    this.consumerSecret = consumerSecret;
     this.loginUrl = loginUrl;
   }
 
@@ -46,12 +46,12 @@ public class AuthenticatorCredentials implements Serializable {
     return password;
   }
 
-  public String getClientId() {
-    return clientId;
+  public String getConsumerKey() {
+    return consumerKey;
   }
 
-  public String getClientSecret() {
-    return clientSecret;
+  public String getConsumerSecret() {
+    return consumerSecret;
   }
 
   public String getLoginUrl() {
@@ -71,13 +71,13 @@ public class AuthenticatorCredentials implements Serializable {
 
     return Objects.equals(username, that.username) &&
       Objects.equals(password, that.password) &&
-      Objects.equals(clientId, that.clientId) &&
-      Objects.equals(clientSecret, that.clientSecret) &&
+      Objects.equals(consumerKey, that.consumerKey) &&
+      Objects.equals(consumerSecret, that.consumerSecret) &&
       Objects.equals(loginUrl, that.loginUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(username, password, clientId, clientSecret, loginUrl);
+    return Objects.hash(username, password, consumerKey, consumerSecret, loginUrl);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
@@ -30,15 +30,15 @@ import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
  */
 public class BaseSalesforceConfig extends ReferencePluginConfig {
 
-  @Name(SalesforceConstants.PROPERTY_CLIENT_ID)
-  @Description("Salesforce connected app's client ID")
+  @Name(SalesforceConstants.PROPERTY_CONSUMER_KEY)
+  @Description("Salesforce connected app's consumer key")
   @Macro
-  private String clientId;
+  private String consumerKey;
 
-  @Name(SalesforceConstants.PROPERTY_CLIENT_SECRET)
+  @Name(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
   @Description("Salesforce connected app's client secret key")
   @Macro
-  private String clientSecret;
+  private String consumerSecret;
 
   @Name(SalesforceConstants.PROPERTY_USERNAME)
   @Description("Salesforce username")
@@ -65,23 +65,23 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
   @Macro
   private String errorHandling;
 
-  public BaseSalesforceConfig(String referenceName, String clientId, String clientSecret,
+  public BaseSalesforceConfig(String referenceName, String consumerKey, String consumerSecret,
                               String username, String password, String loginUrl, String errorHandling) {
     super(referenceName);
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
+    this.consumerKey = consumerKey;
+    this.consumerSecret = consumerSecret;
     this.username = username;
     this.password = password;
     this.loginUrl = loginUrl;
     this.errorHandling = errorHandling;
   }
 
-  public String getClientId() {
-    return clientId;
+  public String getConsumerKey() {
+    return consumerKey;
   }
 
-  public String getClientSecret() {
-    return clientSecret;
+  public String getConsumerSecret() {
+    return consumerSecret;
   }
 
   public String getUsername() {
@@ -108,7 +108,8 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
   }
 
   public AuthenticatorCredentials getAuthenticatorCredentials() {
-    return SalesforceConnectionUtil.getAuthenticatorCredentials(username, password, clientId, clientSecret, loginUrl);
+    return SalesforceConnectionUtil.getAuthenticatorCredentials(username, password,
+                                                                consumerKey, consumerSecret, loginUrl);
   }
 
   /**
@@ -118,8 +119,8 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
    * @return true if none of the connection properties contains macro, false otherwise
    */
   public boolean canAttemptToEstablishConnection() {
-    return !(containsMacro(SalesforceConstants.PROPERTY_CLIENT_ID)
-      || containsMacro(SalesforceConstants.PROPERTY_CLIENT_SECRET)
+    return !(containsMacro(SalesforceConstants.PROPERTY_CONSUMER_KEY)
+      || containsMacro(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
       || containsMacro(SalesforceConstants.PROPERTY_USERNAME)
       || containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
       || containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -60,8 +60,8 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
   private Integer offset;
 
   protected SalesforceBaseSourceConfig(String referenceName,
-                                       String clientId,
-                                       String clientSecret,
+                                       String consumerKey,
+                                       String consumerSecret,
                                        String username,
                                        String password,
                                        String loginUrl,
@@ -69,7 +69,7 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
                                        @Nullable String datetimeFilter,
                                        @Nullable Integer duration,
                                        @Nullable Integer offset) {
-    super(referenceName, clientId, clientSecret, username, password, loginUrl, errorHandling);
+    super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, errorHandling);
     this.datetimeFilter = datetimeFilter;
     this.duration = duration;
     this.offset = offset;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -42,8 +42,8 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
     ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>()
       .put(SalesforceConstants.CONFIG_USERNAME, config.getUsername())
       .put(SalesforceConstants.CONFIG_PASSWORD, config.getPassword())
-      .put(SalesforceConstants.CONFIG_CLIENT_ID, config.getClientId())
-      .put(SalesforceConstants.CONFIG_CLIENT_SECRET, config.getClientSecret())
+      .put(SalesforceConstants.CONFIG_CONSUMER_KEY, config.getConsumerKey())
+      .put(SalesforceConstants.CONFIG_CONSUMER_SECRET, config.getConsumerSecret())
       .put(SalesforceConstants.CONFIG_LOGIN_URL, config.getLoginUrl())
       .put(SalesforceSourceConstants.CONFIG_QUERIES, GSON.toJson(queries))
       .put(SalesforceSourceConstants.CONFIG_SCHEMAS, GSON.toJson(schemas));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -69,8 +69,8 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
   private String sObjectNameField;
 
   public SalesforceMultiSourceConfig(String referenceName,
-                              String clientId,
-                              String clientSecret,
+                              String consumerKey,
+                              String consumerSecret,
                               String username,
                               String password,
                               String loginUrl,
@@ -81,7 +81,7 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
                               @Nullable String whiteList,
                               @Nullable String blackList,
                               @Nullable String sObjectNameField) {
-    super(referenceName, clientId, clientSecret, username, password, loginUrl, errorHandling,
+    super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, errorHandling,
       datetimeFilter, duration, offset);
     this.whiteList = whiteList;
     this.blackList = blackList;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -57,8 +57,8 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
 
   @VisibleForTesting
   SalesforceSourceConfig(String referenceName,
-                                String clientId,
-                                String clientSecret,
+                                String consumerKey,
+                                String consumerSecret,
                                 String username,
                                 String password,
                                 String loginUrl,
@@ -69,7 +69,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                                 @Nullable Integer duration,
                                 @Nullable Integer offset,
                                 @Nullable String schema) {
-    super(referenceName, clientId, clientSecret, username, password, loginUrl, errorHandling,
+    super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, errorHandling,
       datetimeFilter, duration, offset);
     this.query = query;
     this.sObjectName = sObjectName;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -104,10 +104,10 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
   @Name("pushTopicNotifyForFields")
   private String pushTopicNotifyForFields;
 
-  public SalesforceStreamingSourceConfig(String referenceName, String clientId, String clientSecret,
+  public SalesforceStreamingSourceConfig(String referenceName, String consumerKey, String consumerSecret,
                                          String username, String password, String loginUrl,
                                          String errorHandling, String pushTopicName, String sObjectName) {
-    super(referenceName, clientId, clientSecret, username, password, loginUrl, errorHandling);
+    super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, errorHandling);
     this.pushTopicName = pushTopicName;
     this.sObjectName = sObjectName;
   }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
@@ -50,19 +50,20 @@ import java.util.stream.Stream;
  *
  * Instructions to enable the tests:
  * 1. Create/use existing Salesforce account
- * 2. Create connected application within the account to get clientId and clientSecret
+ * 2. Create connected application within the account to get consumer key and consumer secret.
  * 3. Run the tests using the command below:
  *
  * mvn clean test
- * -Dsalesforce.test.clientId= -Dsalesforce.test.clientSecret= -Dsalesforce.test.username= -Dsalesforce.test.password=
+ * -Dsalesforce.test.consumerKey= -Dsalesforce.test.consumerSecret=
+ * -Dsalesforce.test.username= -Dsalesforce.test.password=
  *
  */
 public abstract class BaseSalesforceETLTest extends HydratorTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseSalesforceETLTest.class);
 
-  protected static final String CLIENT_ID = System.getProperty("salesforce.test.clientId");
-  protected static final String CLIENT_SECRET = System.getProperty("salesforce.test.clientSecret");
+  protected static final String CONSUMER_KEY = System.getProperty("salesforce.test.consumerKey");
+  protected static final String CONSUMER_SECRET = System.getProperty("salesforce.test.consumerSecret");
   protected static final String USERNAME = System.getProperty("salesforce.test.username");
   protected static final String PASSWORD = System.getProperty("salesforce.test.password");
   protected static final String LOGIN_URL = System.getProperty("salesforce.test.loginUrl",
@@ -76,7 +77,7 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
   @BeforeClass
   public static void initializeTests() throws ConnectionException {
     try {
-      Assume.assumeNotNull(CLIENT_ID, CLIENT_SECRET, USERNAME, PASSWORD, LOGIN_URL);
+      Assume.assumeNotNull(CONSUMER_KEY, CONSUMER_SECRET, USERNAME, PASSWORD, LOGIN_URL);
     } catch (AssumptionViolatedException e) {
       LOG.warn("ETL tests are skipped. Please find the instructions on enabling it at" +
         "BaseSalesforceBatchSourceETLTest javadoc");
@@ -84,7 +85,7 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
     }
 
     AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(
-      USERNAME, PASSWORD, CLIENT_ID, CLIENT_SECRET, LOGIN_URL);
+      USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL);
     partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
   }
 
@@ -135,8 +136,8 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
   protected ImmutableMap.Builder<String, String> getBaseProperties(String referenceName) {
     return new ImmutableMap.Builder<String, String>()
       .put(Constants.Reference.REFERENCE_NAME, referenceName)
-      .put(SalesforceConstants.PROPERTY_CLIENT_ID, CLIENT_ID)
-      .put(SalesforceConstants.PROPERTY_CLIENT_SECRET, CLIENT_SECRET)
+      .put(SalesforceConstants.PROPERTY_CONSUMER_KEY, CONSUMER_KEY)
+      .put(SalesforceConstants.PROPERTY_CONSUMER_SECRET, CONSUMER_SECRET)
       .put(SalesforceConstants.PROPERTY_USERNAME, USERNAME)
       .put(SalesforceConstants.PROPERTY_PASSWORD, PASSWORD)
       .put(SalesforceConstants.PROPERTY_LOGIN_URL, LOGIN_URL)

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -21,8 +21,8 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
  */
 public class SalesforceSourceConfigBuilder {
   private String referenceName;
-  private String clientId;
-  private String clientSecret;
+  private String consumerKey;
+  private String consumerSecret;
   private String username;
   private String password;
   private String loginUrl;
@@ -39,13 +39,13 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setClientId(String clientId) {
-    this.clientId = clientId;
+  public SalesforceSourceConfigBuilder setConsumerKey(String consumerKey) {
+    this.consumerKey = consumerKey;
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setClientSecret(String clientSecret) {
-    this.clientSecret = clientSecret;
+  public SalesforceSourceConfigBuilder setConsumerSecret(String consumerSecret) {
+    this.consumerSecret = consumerSecret;
     return this;
   }
 
@@ -100,7 +100,7 @@ public class SalesforceSourceConfigBuilder {
   }
 
   public SalesforceSourceConfig build() {
-    return new SalesforceSourceConfig(referenceName, clientId, clientSecret, username, password, loginUrl,
+    return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       errorHandling, query, sObjectName, datetimeFilter, duration, offset, schema);
   }
 }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -28,13 +28,13 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Client Id",
-          "name": "clientId"
+          "label": "Consumer Key",
+          "name": "consumerKey"
         },
         {
           "widget-type": "password",
-          "label": "Client Secret",
-          "name": "clientSecret"
+          "label": "Consumer Secret",
+          "name": "consumerSecret"
         },
         {
           "widget-type": "textbox",

--- a/widgets/Salesforce-streamingsource.json
+++ b/widgets/Salesforce-streamingsource.json
@@ -28,13 +28,13 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Client Id",
-          "name": "clientId"
+          "label": "Consumer Key",
+          "name": "consumerKey"
         },
         {
           "widget-type": "password",
-          "label": "Client Secret",
-          "name": "clientSecret"
+          "label": "Consumer Secret",
+          "name": "consumerSecret"
         },
         {
           "widget-type": "textbox",

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -28,13 +28,13 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Client Id",
-          "name": "clientId"
+          "label": "Consumer Key",
+          "name": "consumerKey"
         },
         {
           "widget-type": "password",
-          "label": "Client Secret",
-          "name": "clientSecret"
+          "label": "Consumer Secret",
+          "name": "consumerSecret"
         },
         {
           "widget-type": "textbox",


### PR DESCRIPTION
Since Salesforce uses Consumer Key / Consumer Secret on the Web UI instead of Client Id / Client Secret. Rename properties for three plugins: batch source, batch multi source, realtime source.

This was pointed out by Albert in PR https://github.com/data-integrations/salesforce/pull/20