### PR TITLE
CDAP-15354 Salesforce plugins don't show exact authentication failure reason

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthResponse.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthResponse.java
@@ -34,15 +34,17 @@ public class AuthResponse {
   @SerializedName("issued_at")
   private final String issuedAt;
   private final String signature;
+  private final String error;
 
   public AuthResponse(String accessToken, String instanceUrl, String id, String tokenType,
-                       String issuedAt, String signature) {
+                       String issuedAt, String signature, String error) {
     this.accessToken = accessToken;
     this.instanceUrl = instanceUrl;
     this.id = id;
     this.tokenType = tokenType;
     this.issuedAt = issuedAt;
     this.signature = signature;
+    this.error = error;
   }
 
   public String getAccessToken() {
@@ -69,6 +71,10 @@ public class AuthResponse {
     return signature;
   }
 
+  public String getError() {
+    return error;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -85,11 +91,12 @@ public class AuthResponse {
       Objects.equals(id, that.id) &&
       Objects.equals(tokenType, that.tokenType) &&
       Objects.equals(issuedAt, that.issuedAt) &&
-      Objects.equals(signature, that.signature));
+      Objects.equals(signature, that.signature) &&
+      Objects.equals(error, that.error));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(accessToken, instanceUrl, id, tokenType, issuedAt, signature);
+    return Objects.hash(accessToken, instanceUrl, id, tokenType, issuedAt, signature, error);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.salesforce.authenticator;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.sforce.ws.ConnectorConfig;
 import io.cdap.plugin.salesforce.SalesforceConstants;
@@ -74,7 +75,15 @@ public class Authenticator {
         .param("client_secret", credentials.getConsumerSecret())
         .param("username", credentials.getUsername())
         .param("password", credentials.getPassword()).send().getContentAsString();
-      return GSON.fromJson(response, AuthResponse.class);
+
+      AuthResponse authResponse = GSON.fromJson(response, AuthResponse.class);
+
+      if (!Strings.isNullOrEmpty(authResponse.getError())) {
+        throw new IllegalArgumentException(
+          String.format("Cannot authenticate to Salesforce with given credentials. ServerResponse='%s'", response));
+      }
+
+      return authResponse;
     } finally {
       httpClient.stop();
     }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/BaseSalesforceConfig.java
@@ -114,9 +114,8 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
 
     try {
       SalesforceConnectionUtil.getPartnerConnection(this.getAuthenticatorCredentials());
-    } catch (ConnectionException | IllegalArgumentException e) {
-      String errorMessage = "Cannot connect to Salesforce API with credentials specified";
-      throw new IllegalArgumentException(errorMessage, e);
+    } catch (ConnectionException e) {
+      throw new RuntimeException("There was issue communicating with Salesforce", e);
     }
   }
 }


### PR DESCRIPTION
Currently the exception looks like this when authentication fails due to let's say incorrect credenetials:

```
java.lang.IllegalArgumentException: Cannot connect to Salesforce API with credentials specified
 at io.cdap.plugin.salesforce.plugin.BaseSalesforceConfig.validateConnection(BaseSalesforceConfig.java:137) ~[na:na]
 at 
 ...
 Caused by: java.lang.IllegalArgumentException: illegal service endpoint null
 at com.sforce.ws.ConnectorConfig.setServiceEndpoint(ConnectorConfig.java:294) ~[na:na]
 at com.sforce.soap.partner.PartnerConnection.<init>(PartnerConnection.java:426) ~[na:na]
 at io.cdap.plugin.salesforce.SalesforceConnectionUtil.getPartnerConnection(SalesforceConnectionUtil.java:41) ~[na:na]
 at io.cdap.plugin.salesforce.plugin.BaseSalesforceConfig.validateConnection(BaseSalesforceConfig.java:134) ~[na:na]
 ... 30 common frames omitted
```
However authentication failure can happen due to multitude or different reasons:

```
{"error":"invalid_grant","error_description":"authentication failure - Invalid Password"}
OR
{"error":"invalid_grant","error_description":"client identifier invalid"}
OR
{"error":"invalid_grant", "error_description" : "Token has been revoked."}
OR
{"error":"invalid_grant","error_description":"ip restricted"}
OR
{"error": "invalid_grant","error_description": "expired authorization code"}
OR
{"error" : "invalid_grant", "error_description" : "user hasn't approved this consumer"}
ETC
```
We should include this information and construct a proper exception early on, rather than waiting for login fail with non-informative java.lang.IllegalArgumentException: null

Here's how it looks like with the change introduced:

```
java.lang.IllegalArgumentException: Cannot not authenticate to Salesforce with given credentials. ServerResponse='{"error":"invalid_grant","error_description":"ip restricted"}'
 at io.cdap.plugin.salesforce.authenticator.Authenticator.oauthLogin(Authenticator.java:83) ~[na:na]
 at io.cdap.plugin.salesforce.authenticator.Authenticator.createConnectorConfig(Authenticator.java:42) ~[na:na]
```